### PR TITLE
NuPlayerDecoder: add synchronous call pause()

### DIFF
--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
@@ -54,7 +54,6 @@ protected:
     sp<Renderer> mRenderer;
     size_t mAggregateBufferSizeBytes;
     int64_t mSkipRenderingUntilMediaTimeUs;
-    bool mPaused;
     bool mReachedEOS;
 
     // Used by feedDecoderInputData to aggregate small buffers into


### PR DESCRIPTION
To ensure decoder will not request or send out data.

Port of AOSP commit: 3bc667014875aba35102941b3997d242c303aa0d

Bug: 25372978
was change-id Id66ab9b9961d5a3b9fb783ae73c27ed1c8054db8

CRs-Fixed: 950212
Change-Id: I3343c5bf244885c4cbbe040192573e6d75c01d6a
